### PR TITLE
Fix unregister error when deleting whisper_props from Scene type

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2080,7 +2080,7 @@ def unregister():
     bpy.types.SEQUENCER_PT_effect.remove(copyto_panel_append)
     print(f"Unregistering {bl_info['name']} Addon")
     # Delete the property group from Scene first
-    del Scene.whisper_props
+    del bpy.types.Scene.whisper_props
 
     for cls in reversed(classes):
         try:


### PR DESCRIPTION
The unregister function was incorrectly using `del Scene.whisper_props`, which caused an AttributeError during addon unregistration. 


This PR corrects it to:  
```python
del bpy.types.Scene.whisper_props
```
